### PR TITLE
Add Excel conversion tool and JSON viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Sankay Minute
 
-Ce dépôt contient un exemple minimal d'interface web permettant de générer dynamiquement un diagramme de Sankey à l'aide de [Plotly](https://plotly.com/javascript/sankey-diagrams/). Le fichier `sankay-minute-configurable.html` propose quelques champs de saisie pour personnaliser les libellés, les valeurs et les couleurs des différentes branches.
+Ce dépôt contient un exemple minimal d'interface web permettant de générer dynamiquement un diagramme de Sankey à l'aide de [Plotly](https://plotly.com/javascript/sankey-diagrams/). Le fichier `sankay-minute-configurable.html` propose quelques champs de saisie pour personnaliser les libellés, les valeurs et les couleurs des différentes branches.  Une seconde page permet d'afficher automatiquement un diagramme à partir d'un fichier JSON généré depuis Excel.
 
-## Fichier principal
+## Fichiers principaux
 
-- **sankay-minute-configurable.html** : page HTML autonome incluant un script JavaScript pour afficher un diagramme de Sankey. Les données sont lues dans les champs du formulaire puis utilisées pour mettre à jour le graphe via `Plotly.react()`.
+- **sankay-minute-configurable.html** : page HTML autonome incluant un script JavaScript pour saisir manuellement quelques valeurs de test puis mettre à jour le graphe via `Plotly.react()`.
+- **sankey-from-json.html** : page HTML qui charge automatiquement un fichier `data.json` (généré depuis Excel) et affiche le diagramme.
 
 Extrait du code :
 ```html
@@ -37,8 +38,19 @@ Ces valeurs alimentent ensuite la configuration du diagramme de Sankey.
 1. Ouvrir `sankay-minute-configurable.html` dans un navigateur moderne.
 2. Modifier les libellés, pourcentages et couleurs selon vos besoins.
 3. Cliquer sur **Mettre à jour le diagramme** pour rafraîchir la visualisation.
+4. Pour afficher vos propres données, générez un `data.json` à partir d'un fichier Excel puis ouvrez `sankey-from-json.html` (idéalement via `python -m http.server`).
 
 Cette page peut servir de base pour créer rapidement des schémas de flux personnalisés.
+
+## Conversion depuis Excel
+
+Un script Python est fourni pour transformer un tableau Excel en fichier JSON compatible avec Plotly.
+
+```bash
+python scripts/convert_excel_to_sankey.py mon_tableau.xlsx
+```
+
+Cela génère un fichier `data.json` que vous pouvez ensuite afficher avec la page `sankey-from-json.html`. Servez les fichiers via un petit serveur local (`python -m http.server`) pour permettre le chargement du JSON.
 
 ## Notes
 

--- a/sankey-from-json.html
+++ b/sankey-from-json.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Diagramme Sankey depuis Excel</title>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; padding: 20px; background: #f5f5f5; }
+        #sankey { margin-top: 20px; }
+    </style>
+</head>
+<body>
+<h2>Diagramme Sankey généré à partir d'un fichier Excel</h2>
+<p>Exécutez le script <code>scripts/convert_excel_to_sankey.py</code> pour produire <code>data.json</code> puis rechargez cette page.</p>
+<div id="sankey">Chargement en cours…</div>
+<script>
+async function loadData() {
+    try {
+        const response = await fetch('data.json');
+        const json = await response.json();
+        renderSankey(json);
+    } catch (e) {
+        document.getElementById('sankey').innerText = 'Impossible de charger data.json : ' + e;
+    }
+}
+
+function renderSankey(json) {
+    const data = {
+        type: 'sankey',
+        orientation: 'h',
+        node: {
+            pad: 15,
+            thickness: 30,
+            line: {color: 'black', width: 0.5},
+            label: json.node.label
+        },
+        link: json.link
+    };
+    Plotly.newPlot('sankey', [data], {font: {size: 14}});
+}
+
+loadData();
+</script>
+</body>
+</html>

--- a/scripts/convert_excel_to_sankey.py
+++ b/scripts/convert_excel_to_sankey.py
@@ -1,0 +1,54 @@
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def excel_to_sankey(path: str) -> dict:
+    """Convertit un fichier Excel en dictionnaire compatible avec Plotly Sankey."""
+    df = pd.read_excel(path)
+    df = df.rename(columns={c: c.lower() for c in df.columns})
+
+    required = {"source", "target", "value"}
+    if not required.issubset(df.columns):
+        raise ValueError(
+            f"Les colonnes requises {required} sont absentes du fichier {path}"
+        )
+
+    labels = pd.unique(df[["source", "target"]].values.ravel())
+    label_index = {label: i for i, label in enumerate(labels)}
+
+    sources = df["source"].map(label_index).astype(int).tolist()
+    targets = df["target"].map(label_index).astype(int).tolist()
+    values = df["value"].astype(float).tolist()
+
+    data = {
+        "node": {"label": labels.tolist()},
+        "link": {"source": sources, "target": targets, "value": values},
+    }
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convertit un tableau Excel en fichier JSON pour un diagramme Sankey"
+    )
+    parser.add_argument("excel_file", help="Chemin du fichier Excel contenant les colonnes source, target et value")
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="data.json",
+        help="Nom du fichier JSON de sortie (par d\u00e9faut data.json)",
+    )
+    args = parser.parse_args()
+
+    data = excel_to_sankey(args.excel_file)
+    Path(args.output).write_text(
+        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    print(f"Fichier {args.output} g\u00e9n\u00e9r\u00e9 avec succ\u00e8s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python script to convert Excel data to Plotly Sankey JSON
- create `sankey-from-json.html` that loads `data.json`
- document workflow in README

## Testing
- `python -m py_compile scripts/convert_excel_to_sankey.py`
- `python scripts/convert_excel_to_sankey.py /tmp/tmp5opcz5_j.xlsx -o /tmp/test.json`

------
https://chatgpt.com/codex/tasks/task_e_68493f4ac2a4832f852453e19bcffecb