### PR TITLE
Remove unused sample Excel file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Ce dépôt contient un exemple minimal d'interface web permettant de générer dynamiquement un diagramme de Sankey à l'aide de [Plotly](https://plotly.com/javascript/sankey-diagrams/). Le fichier `sankay-minute-configurable.html` propose quelques champs de saisie pour personnaliser les libellés, les valeurs et les couleurs des différentes branches.  Une seconde page permet d'afficher automatiquement un diagramme à partir d'un fichier JSON généré depuis Excel.
 
+> **Note**
+> Le dépôt ne fournit plus de fichier Excel d'exemple (`sample_data.xlsx`).
+> Pour tester le script de conversion, utilisez votre propre classeur ou préparez un petit fichier CSV que vous convertirez ensuite en Excel.
+
 ## Fichiers principaux
 
 - **sankay-minute-configurable.html** : page HTML autonome incluant un script JavaScript pour saisir manuellement quelques valeurs de test puis mettre à jour le graphe via `Plotly.react()`.
@@ -44,7 +48,7 @@ Cette page peut servir de base pour créer rapidement des schémas de flux perso
 
 ## Conversion depuis Excel
 
-Un script Python est fourni pour transformer un tableau Excel en fichier JSON compatible avec Plotly.
+Un script Python est fourni pour transformer un tableau Excel en fichier JSON compatible avec Plotly. Aucun classeur d'exemple n'est conservé dans le dépôt : utilisez votre propre fichier ou convertissez un petit CSV de test en Excel avant d'exécuter le script.
 
 ```bash
 python scripts/convert_excel_to_sankey.py mon_tableau.xlsx


### PR DESCRIPTION
## Summary
- remove reference to sample_data.xlsx in README
- clarify that users should provide their own Excel or use a CSV

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68498bda3f84832faa8ef91d8704951c